### PR TITLE
48error al cargar un plato nuevo

### DIFF
--- a/app.py
+++ b/app.py
@@ -284,8 +284,8 @@ def update(id_plato=None):
             # Guardamos la foto en la carpeta correspondiente
             foto.save('App_restaurant/fotos/'+nuevoNombreFoto)
             # Buscamos el nombre de la foto vieja
-            if id_plato != None:
-                sql = 'SELECT `foto` FROM `my_resto`.`platos` WHERE id_plato=%s'
+            if id_plato is not None:
+                sql = 'SELECT foto FROM `my_resto`.`platos` WHERE id_plato=%s'
                 cursor.execute(sql, id_plato)
                 fotoVieja = cursor.fetchall()[0][0]
                 borrarFoto(fotoVieja)

--- a/app.py
+++ b/app.py
@@ -284,10 +284,11 @@ def update(id_plato=None):
             # Guardamos la foto en la carpeta correspondiente
             foto.save('App_restaurant/fotos/'+nuevoNombreFoto)
             # Buscamos el nombre de la foto vieja
-            sql = 'SELECT `foto` FROM `my_resto`.`platos` WHERE id_plato=%s'
-            cursor.execute(sql, id_plato)
-            fotoVieja = cursor.fetchall()[0][0]
-            borrarFoto(fotoVieja)
+            if id_plato != None:
+                sql = 'SELECT `foto` FROM `my_resto`.`platos` WHERE id_plato=%s'
+                cursor.execute(sql, id_plato)
+                fotoVieja = cursor.fetchall()[0][0]
+                borrarFoto(fotoVieja)
         else:  # Si no se adjunto un archivo
             nuevoNombreFoto = request.form['viejoNombreFoto']
             if nuevoNombreFoto == '':


### PR DESCRIPTION
Se soluciono el problema que traía un error al crear un plato nuevo, que se debía a que la app buscaba en la DB el nombre de la foto vieja, la cual, obviamente no existía, ya que es un nuevo plato. 
Cerrar issue #48 